### PR TITLE
Update repository_owners

### DIFF
--- a/repository_owners
+++ b/repository_owners
@@ -41,3 +41,4 @@ https://github.com/bociepka/jimp2;297263;pallovsky
 https://github.com/SebastianSuchowiak/JIMP2;297291;none
 https://github.com/FlayJalapeno/JIMP2;FlayJalapeno;none
 https://github.com/Asia17/JiMP2---Binek-Baryla;297183;297179
+https://github.com/zyngjaku/JiMP2;297313;297265


### PR DESCRIPTION
Czy jak robie z osobą spod linii 19 (nr indeksu: 297265), to usunąć jej link do githuba z tego pliku i zostawić tylko jej nr indeksu przy moim linku?